### PR TITLE
Taboo: Add initial login bar widget

### DIFF
--- a/src/css/taboo/room.css
+++ b/src/css/taboo/room.css
@@ -7,3 +7,23 @@
    overflow-x: hidden;
 }
 
+/* login bar related */
+.taboo_login_bar {
+   background: orange;
+}
+
+.taboo_login_bar_team_cell {
+   width: 250px;
+}
+
+.taboo_login_bar_btn_cell {
+   width: 150px;
+}
+
+.taboo_login_bar_alias {
+   width: 150px;
+}
+
+.taboo_login_bar_text {
+   padding: 15px;
+}

--- a/src/js/taboo/room.js
+++ b/src/js/taboo/room.js
@@ -21,11 +21,55 @@ class TabooWidgetBase extends Table {
 class TabooLoginBar extends TabooWidgetBase {
 /**
  *  -------------------------------------------------------
- *  |    Alias [     ]  | Team [ Auto  v]  | [ Connect ]  |
+ *  |    Alias [     ]  | Team [ Auto  v ] | [ Connect ]  |
  *  -------------------------------------------------------
  */
    constructor(room, nw, parent_ui) {
-      super(room, nw, parent_ui, 1, 3);
+      super(room, nw, parent_ui, 1, 3, "taboo_login_bar width100");
+
+      this.host_params_processed = false;
+
+      this.alias = create_input_text(this, "", "taboo_login_bar_alias text");
+      this.team = create_drop_down(this, "", ["Auto"], "Auto", "text");
+      this.connect_btn = create_button(this, "", "Connect",
+                                       this.connect_click,
+                                       "text");
+
+      this.cell_class(0, 0, "right");
+      this.cell_content_add(0, 0, create_span("Alias", "taboo_login_bar_text text"));
+      this.cell_content_add(0, 0, this.alias);
+
+      this.cell_class(0, 1, "taboo_login_bar_team_cell");
+      this.cell_content_add(0, 1, create_span("Team", "taboo_login_bar_text text"));
+      this.cell_content_add(0, 1, this.team);
+
+      this.cell_class(0, 2, "taboo_login_bar_btn_cell");
+      this.cell_content_add(0, 2, this.connect_btn);
+
+      this.alias.focus();
+   }
+
+   connect_click(ev) {
+      var login_bar = ev ? ev.target.creator : this;
+
+      var team = Number(login_bar.team.value);
+      if (isNaN(team)) { // team must have been "Any"
+         team = 0;
+      }
+      login_bar.nw.send(["JOIN", login_bar.alias.value, team]);
+   }
+
+   updateHostParameters() {
+      if (this.host_params_processed) { return; } // Don't process twice
+
+      for (var i=1; i <= this.room.host_parameters["numTeams"]; ++i) {
+         var option = document.createElement("option");
+         option.value = i;
+         option.text = i;
+         this.team.appendChild(option);
+      }
+
+      this.host_params_processed = true;
    }
 }
 
@@ -39,6 +83,8 @@ class TabooRoom extends Ui {
                             this.onclose,
                             this.onopen);
       this.nw.room = this;
+
+      this.host_parameters = null;
       this.game_over = false;
 
       this.init_display();
@@ -46,10 +92,8 @@ class TabooRoom extends Ui {
 
    init_display() {
       // Create other widgets here
-      // Each widget takes pointer to
-      // 1. "this" (the room object)
-      // 2. "this.nw" (the network object to send messages)
-      // 3. "this.div" (where to insert their widgets into)
+
+      this.login_bar = new TabooLoginBar(this, this.nw, this.div);
    }
 
    // Message handling ----------------------------------------------
@@ -57,7 +101,20 @@ class TabooRoom extends Ui {
    onmessage(jmsg) {
       var room = this.room; // this => the network object
 
-      console.log(jmsg);
+      if (jmsg[0] == "HOST-PARAMETERS") {
+         // ["HOST-PARAMETERS", {"numTeams": 1, "turnDurationSec": 30, "wordSets": ["test"], "numTurns": 1}]
+         room.host_parameters = jmsg[1];
+         room.login_bar.updateHostParameters();
+         return;
+      }
+
+      if (jmsg[0] == "JOIN-BAD") {
+         // TODO
+      }
+
+      if (jmsg[0] == "JOIN-OKAY") {
+         // TODO
+      }
    }
 
    // Other socket events -------------------------------------------


### PR DESCRIPTION
It sends the "JOIN" message when the connect button is hit.

We should perhaps add the logic to hide the login-bar immediately on pressing the button (to avoid duplicate sends) and make it reappear on receiving "JOIN-BAD".

We have to figure out where to show all the users (and their ready status!).