### PR TITLE
Taboo: Add wait-for-kickoff widget + turn-word widget

### DIFF
--- a/src/css/taboo/room.css
+++ b/src/css/taboo/room.css
@@ -65,3 +65,34 @@
    padding: 10px;
    filter: drop-shadow(2px 2px 2px #a0a0a0);
 }
+
+/* taboo wait for kickoff widget */
+
+.taboo_wfk {
+   height: 300px;
+}
+
+/* taboo turn word widget */
+
+.taboo_turn_word {
+   height: 300px;
+}
+
+.taboo_turn_word_secret_cell {
+   height: 60px;
+   padding: 15px;
+}
+
+.taboo_turn_word_disallowed_cell {
+   padding: 15px;
+}
+
+.taboo_turn_word_secret {
+   background-color: blue;
+   color: white;
+   padding: 15px;
+   border-radius: 10px;
+}
+
+.taboo_turn_word_disallowed {
+}

--- a/src/css/taboo/room.css
+++ b/src/css/taboo/room.css
@@ -8,8 +8,13 @@
 }
 
 /* login bar related */
+
 .taboo_login_bar {
    background: orange;
+}
+
+.taboo_login_bar_alias_cell {
+   width: 300px;
 }
 
 .taboo_login_bar_team_cell {
@@ -17,7 +22,6 @@
 }
 
 .taboo_login_bar_btn_cell {
-   width: 150px;
 }
 
 .taboo_login_bar_alias {
@@ -26,4 +30,38 @@
 
 .taboo_login_bar_text {
    padding: 15px;
+}
+
+/* taboo ready bar */
+
+.taboo_ready_bar {
+   background-color: orange;
+}
+
+/* taboo notifications table */
+
+.taboo_notifications_table {
+   position: absolute;
+   left: 0px;
+   top: 0px;
+   width: 100%;
+   z-index: 1000;
+   padding: 5px;
+   border-spacing: 10px;
+}
+
+.taboo_notification_info {
+   background-color: rgba(200, 255, 200, 0.8);
+   border-radius: 10px;
+   text-align: center;
+   padding: 10px;
+   filter: drop-shadow(2px 2px 2px #a0a0a0);
+}
+
+.taboo_notification_error {
+   background-color: rgba(255, 200, 200, 0.8);
+   border-radius: 10px;
+   text-align: center;
+   padding: 10px;
+   filter: drop-shadow(2px 2px 2px #a0a0a0);
 }

--- a/src/js/taboo/room.js
+++ b/src/js/taboo/room.js
@@ -28,6 +28,7 @@ class TabooLoginBar extends TabooWidgetBase {
       super(room, nw, parent_ui, 1, 3, "taboo_login_bar width100");
 
       this.host_params_processed = false;
+      this.game_over = false;
 
       this.alias = create_input_text(this, "", "taboo_login_bar_alias text");
       this.team = create_drop_down(this, "", ["Auto"], "Auto", "text");
@@ -47,6 +48,11 @@ class TabooLoginBar extends TabooWidgetBase {
       this.cell_content_add(0, 2, this.connect_btn);
 
       this.alias.focus();
+   }
+
+   process_game_over() {
+      this.game_over = true;
+      this.hide();
    }
 
    connect_click(ev) {
@@ -95,6 +101,147 @@ class TabooReadyBar extends TabooWidgetBase {
 
 }
 
+class TabooWaitForKickoff extends TabooWidgetBase {
+/*
+ * --------------------------------------------------
+ * |                                                |
+ * |           Waiting for <player-name>            |
+ * |                                                |
+ * --------------------------------------------------
+ *
+ * or
+ *
+ * --------------------------------------------------
+ * |                                                |
+ * |                [ START TURN ]                  |
+ * |                                                |
+ * --------------------------------------------------
+ */
+   constructor(room, nw, parent_ui) {
+      super(room, nw, parent_ui, 1, 1, "taboo_wfk width100");
+
+      this.start_turn_btn = create_button(this, "", "Start turn", this.start_turn_click, "head2");
+
+      this.turn_id = null;
+      this.alias = null;
+      this.game_over = false;
+
+      this.cell_class(0, 0, "center");
+   }
+
+   start_turn_click(ev) {
+      var wfk = ev.target.creator;
+      wfk.nw.send(["KICKOFF"]);
+   }
+
+   process_game_over() {
+      this.game_over = true;
+      this.hide();
+   }
+
+   update_alias(turn_id, alias) {
+      if (this.game_over) {
+         return;
+      }
+
+      this.turn_id = turn_id;
+      this.alias = alias;
+
+      this.show();
+      this.room.turn_word_widget.hide();
+
+      this.refresh();
+   }
+
+   refresh() {
+      if (!this.alias) { return; }
+
+      if (this.alias == this.room.login_bar.alias.value) {
+         // My turn
+         this.cell_content_set(0, 0, this.start_turn_btn);
+      } else {
+         // Someone else's turn
+         this.cell_content_set(0, 0, create_span("Wait for " + this.alias, "head1"));
+      }
+   }
+}
+
+class TabooTurnWordWidget extends TabooWidgetBase {
+/*
+ * --------------------------------------------------
+ * |           <wordId>  Main word                  |
+ * --------------------------------------------------
+ * |              Disallowed word 1                 |
+ * |              Disallowed word 2                 |
+ * |              Disallowed word 3                 |
+ * --------------------------------------------------
+ */
+   constructor(room, nw, parent_ui) {
+      super(room, nw, parent_ui, 2, 1, "taboo_turn_word width100");
+
+      this.cell_class(0, 0, "taboo_turn_word_secret_cell center");
+      this.cell_class(1, 0, "taboo_turn_word_disallowed_cell center top");
+
+      this.jmsg = null;
+      this.game_over = false;
+   }
+
+   process_game_over() {
+      this.game_over = true;
+      this.hide();
+   }
+
+   process_turn_msg(jmsg) {
+      if (this.game_over) {
+         return;
+      }
+
+      //["TURN",
+      // turn<int>,
+      // wordIdx<int>,
+      // {"team": <int>,
+      //  "player": <str>,
+      //  "state": IN_PLAY,
+      // }
+      //]
+      if (this.jmsg &&                     // Some word has been received already
+          (jmsg[1] < this.jmsg[1] ||       // Older turn ID
+           (jmsg[1] == this.jmsg[1] &&     // Same turn but older
+            jmsg[2] < this.jmsg[2]))) {    //   word ID
+         // Receiving messages out of order. Ignore older message
+         return;
+      }
+
+      this.jmsg = jmsg;
+
+      clear_contents(this.cell(0, 0));
+      clear_contents(this.cell(1, 0));
+
+      var word_state = jmsg[3]["state"];
+      if (word_state != "IN_PLAY") {      // Only show the word if it is in
+         return;                          // play
+      }
+
+      var word_idx = jmsg[2];
+      var secret_display = word_idx + ".";   // "1."
+      if ("secret" in jmsg[3]) {
+         secret_display += " " + jmsg[3]["secret"];  // "1. <word>"
+
+         for (var idx in jmsg[3]["disallowed"]) {
+            var disallowed = jmsg[3]["disallowed"][idx];
+            if (idx > 0) {
+               this.cell_content_add(1, 0, create_line_break());
+            }
+            this.cell_content_add(1, 0,
+               create_span(disallowed, "taboo_turn_word_disallowed head1"));
+         }
+      }
+      this.cell_content_set(0, 0, create_span(secret_display, "taboo_turn_word_secret head1"));
+      this.show();
+      this.room.wfk.hide();
+   }
+}
+
 class TabooRoom extends Ui {
    constructor(gid, div) {
       super(div);
@@ -119,6 +266,10 @@ class TabooRoom extends Ui {
       this.login_bar = new TabooLoginBar(this, this.nw, this.div);
       this.ready_bar = new TabooReadyBar(this, this.nw, this.div);
       this.ready_bar.hide();
+
+      this.wfk = new TabooWaitForKickoff(this, this.nw, this.div);
+
+      this.turn_word_widget = new TabooTurnWordWidget(this, this.nw, this.div);
    }
 
    // UI helpers ----------------------------------------------------
@@ -136,7 +287,7 @@ class TabooRoom extends Ui {
    // Message handling ----------------------------------------------
 
    onmessage(jmsg) {
-      var room = this.room; // this => the network object
+      var room = this.room || this; // this => the network object
 
       if (jmsg[0] == "HOST-PARAMETERS") {
          // ["HOST-PARAMETERS", {"numTeams": 1, "turnDurationSec": 30, "wordSets": ["test"], "numTurns": 1}]
@@ -149,18 +300,52 @@ class TabooRoom extends Ui {
          room.show_error_msg(jmsg[1]);
          room.login_bar.show();
          room.login_bar.alias.focus();
+         return;
       }
 
       if (jmsg[0] == "JOIN-OKAY") {
          room.show_info_msg("Joined as " + jmsg[1] + " in team " + jmsg[2]);
          room.ready_bar.show();
          room.ready_bar.ready_btn.focus();
+
+         room.wfk.refresh();
+         return;
       }
 
       if (jmsg[0] == "READY-BAD") {
          room.show_error_msg(jmsg[1]);
          room.ready_bar.hide();
+         return;
       }
+
+      if (jmsg[0] == "WAIT-FOR-KICKOFF") {
+         // ["WAIT-FOR-KICKOFF", turn<int>, "player": <str>]
+         room.wfk.update_alias(jmsg[1], jmsg[2]);
+         return;
+      }
+
+      if (jmsg[0] == "TURN") {
+         room.turn_word_widget.process_turn_msg(jmsg);
+         return;
+      }
+
+      if (jmsg[0] == "GAME-OVER") {
+         room.login_bar.process_game_over();
+         room.turn_word_widget.process_game_over();
+         room.wfk.process_game_over();
+         return;
+      }
+
+      if (jmsg[0] == "ERROR") {
+         room.login_bar.hide();
+         room.turn_word_widget.hide();
+         room.wfk.hide();
+         room.show_error_msg("Room not created yet");
+         return;
+      }
+
+      console.log("Unhandled message");
+      console.log(jmsg);
    }
 
    // Other socket events -------------------------------------------


### PR DESCRIPTION
I think we should rewrite differently such that there is no explicit dispatch from room. Each widget can define it's own process_msg() which is where it's logic can reside (about hiding itself etc)